### PR TITLE
adding kubernetes-intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # Faoxis_platform
 Faoxis Platform repository
+
+
+## Домашняя работа 1. Введение в Kubernetes
+### Порядок выполнения:
+1) Установил `minikube`
+2) Запусти `kubernetes` кластер командой `minikube start`
+3) Создал [`Dockerfile`](kubernetes-intro/web/Dockerfile) с открытым портом `8000` и возможностью подгружать ресурсы из `/app/`.
+4) Создал [манифест](kubernetes-intro/web-pod.yaml) с поднятием моего образа в `kubernetes` с `init` контейнером, который подкладывает файл `index.html` в папку с ресурсами.
+5) Запустил под командой `kubectl apply -f web-pod.yaml`.
+6) Убедился в работоспособности пода командой `kubectl describe pod web`.
+7) Проверил, что скаченная страница подгружается командой `kubectl port-forward --address 0.0.0.0 pod/web 8000:8000`.
+8) Получил файл с описанием нового сервис `frontend` командой `kubectl run frontend --image avtandilko/hipster-frontend:v0.0.1 --restart=Never --dry-run=client -o yaml > frontend-pod.yaml`.
+9) Через команду `docker logs frontend` понял каких переменных окружения не хватает и добавил их в файле [`frontend-pod-health.yaml`](kubernetes-intro/frontend-pod-healthy.yaml).
+### Ответы на вопросы:
+1) Разберитесь почему все pod в namespace kube-system восстановились после удаления

--- a/README.md
+++ b/README.md
@@ -16,15 +16,15 @@ Faoxis Platform repository
 ### Ответы на вопросы:
 #### Разберитесь почему все pod в namespace kube-system восстановились после удаления. Для ответа на вопрос попробуем проделать следующий действия:
 1) Выполним команду `kubectl delete pod --all -n kube-system`, а затем `kubectl get pods -n kube-system`, чтобы убедиться, что поды на месте:
-```shell
-NAME                               READY   STATUS    RESTARTS   AGE
-coredns-f9fd979d6-5d25r            1/1     Running   0          50s
-etcd-minikube                      1/1     Running   0          50s
-kube-apiserver-minikube            1/1     Running   0          50s
-kube-controller-manager-minikube   1/1     Running   0          50s
-kuяbe-proxy-nlw69                   1/1     Running   0          43s
-kube-scheduler-minikube            1/1     Running   0          49s
-```
+    ```shell
+    NAME                               READY   STATUS    RESTARTS   AGE
+    coredns-f9fd979d6-5d25r            1/1     Running   0          50s
+    etcd-minikube                      1/1     Running   0          50s
+    kube-apiserver-minikube            1/1     Running   0          50s
+    kube-controller-manager-minikube   1/1     Running   0          50s
+    kuяbe-proxy-nlw69                   1/1     Running   0          43s
+    kube-scheduler-minikube            1/1     Running   0          49s
+    ```
 2) Далее нам необходимо проверить участие `Replica Set` и `Daemon Set` в поднятии подов. Для этого выполним следующие команды и посмотрим на результат:
     ```shell
     ➜  ~ kubectl get ds -n kube-system

--- a/README.md
+++ b/README.md
@@ -14,4 +14,29 @@ Faoxis Platform repository
 8) Получил файл с описанием нового сервис `frontend` командой `kubectl run frontend --image avtandilko/hipster-frontend:v0.0.1 --restart=Never --dry-run=client -o yaml > frontend-pod.yaml`.
 9) Через команду `docker logs frontend` понял каких переменных окружения не хватает и добавил их в файле [`frontend-pod-health.yaml`](kubernetes-intro/frontend-pod-healthy.yaml).
 ### Ответы на вопросы:
-1) Разберитесь почему все pod в namespace kube-system восстановились после удаления
+#### Разберитесь почему все pod в namespace kube-system восстановились после удаления. Для ответа на вопрос попробуем проделать следующий действия:
+1) Выполним команду `kubectl delete pod --all -n kube-system`, а затем `kubectl get pods -n kube-system`, чтобы убедиться, что поды на месте:
+```shell
+NAME                               READY   STATUS    RESTARTS   AGE
+coredns-f9fd979d6-5d25r            1/1     Running   0          50s
+etcd-minikube                      1/1     Running   0          50s
+kube-apiserver-minikube            1/1     Running   0          50s
+kube-controller-manager-minikube   1/1     Running   0          50s
+kuяbe-proxy-nlw69                   1/1     Running   0          43s
+kube-scheduler-minikube            1/1     Running   0          49s
+```
+2) Далее нам необходимо проверить участие `Replica Set` и `Daemon Set` в поднятии подов. Для этого выполним следующие команды и посмотрим на результат:
+    ```shell
+    ➜  ~ kubectl get ds -n kube-system
+    NAME         DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR            AGE
+    kube-proxy   1         1         1       1            1           kubernetes.io/os=linux   18m
+    ➜  ~ kubectl get rs -n kube-system
+    NAME                DESIRED   CURRENT   READY   AGE
+    coredns-f9fd979d6   1         1         1       18m
+    ```
+3) По результату выше можно сделать вывод о том, что `kube-proxy` работает благодаря записи о нем в `Daemon Set`, а `coredns` с помощью `Replica Set`.
+4) Остальные поды выглядят странно: у них нет динамического идентификатора, а значит принцип их работы отличается.
+    После небольшого поиска в интернете, понял, что бывают динамические и статические поды. 
+    Динамические поды поднимаются с помощью записи о них в `Replica Set` и `Daemon Set`.
+    Статические поднимаются благодаря `kubelet` демону, который фиксирует статические поды по манифестам в директории `/etc/kubelet.d/` (по умолчанию) и "следит" за жизнью работающих статических подов.
+    Сам `kubelet` востанавливает свою работу благодаря `linux` инструменту демонизации процессов `systemd`.

--- a/kubernetes-intro/frontend-pod-healthy.yaml
+++ b/kubernetes-intro/frontend-pod-healthy.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    run: frontend
+  name: frontend
+spec:
+  containers:
+    - image: avtandilko/hipster-frontend:v0.0.1
+      name: frontend
+      env:
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "productcatalogservice:3550"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "currencyservice:7000"
+        - name: CART_SERVICE_ADDR
+          value: "cartservice:7070"
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: "recommendationservice:8080"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "shippingservice:50051"
+        - name: CHECKOUT_SERVICE_ADDR
+          value: "checkoutservice:5050"
+        - name: AD_SERVICE_ADDR
+          value: "adservice:9555"
+        - name: ENV_PLATFORM
+          value: "gcp"
+  dnsPolicy: ClusterFirst
+  restartPolicy: Never
+status: {}

--- a/kubernetes-intro/frontend-pod.yaml
+++ b/kubernetes-intro/frontend-pod.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    run: frontend
+  name: frontend
+spec:
+  containers:
+  - image: avtandilko/hipster-frontend:v0.0.1
+    name: frontend
+    resources: {}
+  dnsPolicy: ClusterFirst
+  restartPolicy: Never
+status: {}

--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1 # Версия API
+kind: Pod # Объект, который создаем
+metadata:
+  name: web # Название Pod
+  labels: # Метки в формате key: value
+    app: web
+spec: # Описание Pod
+  containers: # Описание контейнеров внутри Pod
+  - name: web # Название контейнера
+    image: registry.hub.docker.com/faoxis/otus-nginx:0.0.1 # Образ из которого создается контейнер
+    volumeMounts:
+      - name: app
+        mountPath: /app
+  initContainers:
+  - name: busybox
+    image: busybox:1.31.0
+    command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
+    volumeMounts:
+    - name: app
+      mountPath: /app
+  volumes:
+  - name: app
+    emptyDir: {}

--- a/kubernetes-intro/web/Dockerfile
+++ b/kubernetes-intro/web/Dockerfile
@@ -1,0 +1,7 @@
+from nginx:latest
+
+RUN mkdir /app
+COPY web.conf /etc/nginx/conf.d/web.conf
+
+
+EXPOSE 8000

--- a/kubernetes-intro/web/build-and-push.sh
+++ b/kubernetes-intro/web/build-and-push.sh
@@ -1,0 +1,3 @@
+docker login registry.hub.docker.com -u faoxis
+docker build . -t registry.hub.docker.com/faoxis/otus-nginx:0.0.1
+docker push registry.hub.docker.com/faoxis/otus-nginx:0.0.1

--- a/kubernetes-intro/web/homework.html
+++ b/kubernetes-intro/web/homework.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Homework</title>
+</head>
+<body>
+    <h1>It works!</h1>
+</body>
+</html>

--- a/kubernetes-intro/web/web.conf
+++ b/kubernetes-intro/web/web.conf
@@ -1,0 +1,45 @@
+server {
+    listen       8000;
+    listen  [::]:8000;
+    server_name  localhost;
+
+    #charset koi8-r;
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location / {
+        root   /app;
+        index  index.html index.htm;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+    #
+    #location ~ \.php$ {
+    #    proxy_pass   http://127.0.0.1;
+    #}
+
+    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+    #
+    #location ~ \.php$ {
+    #    root           html;
+    #    fastcgi_pass   127.0.0.1:9000;
+    #    fastcgi_index  index.php;
+    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+    #    include        fastcgi_params;
+    #}
+
+    # deny access to .htaccess files, if Apache's document root
+    # concurs with nginx's one
+    #
+    #location ~ /\.ht {
+    #    deny  all;
+    #}
+}


### PR DESCRIPTION
# Выполнено ДЗ № 1

### Порядок выполнения:
1) Установил `minikube`
2) Запусти `kubernetes` кластер командой `minikube start`
3) Создал [`Dockerfile`](kubernetes-intro/web/Dockerfile) с открытым портом `8000` и возможностью подгружать ресурсы из `/app/`.
4) Создал [манифест](kubernetes-intro/web-pod.yaml) с поднятием моего образа в `kubernetes` с `init` контейнером, который подкладывает файл `index.html` в папку с ресурсами.
5) Запустил под командой `kubectl apply -f web-pod.yaml`.
6) Убедился в работоспособности пода командой `kubectl describe pod web`.
7) Проверил, что скаченная страница подгружается командой `kubectl port-forward --address 0.0.0.0 pod/web 8000:8000`.
8) Получил файл с описанием нового сервис `frontend` командой `kubectl run frontend --image avtandilko/hipster-frontend:v0.0.1 --restart=Never --dry-run=client -o yaml > frontend-pod.yaml`.
9) Через команду `docker logs frontend` понял каких переменных окружения не хватает и добавил их в файле [`frontend-pod-health.yaml`](kubernetes-intro/frontend-pod-healthy.yaml).
### Ответы на вопросы:
#### Разберитесь почему все pod в namespace kube-system восстановились после удаления. Для ответа на вопрос попробуем проделать следующий действия:
1) Выполним команду `kubectl delete pod --all -n kube-system`, а затем `kubectl get pods -n kube-system`, чтобы убедиться, что поды на месте:
```shell
NAME                               READY   STATUS    RESTARTS   AGE
coredns-f9fd979d6-5d25r            1/1     Running   0          50s
etcd-minikube                      1/1     Running   0          50s
kube-apiserver-minikube            1/1     Running   0          50s
kube-controller-manager-minikube   1/1     Running   0          50s
kuяbe-proxy-nlw69                   1/1     Running   0          43s
kube-scheduler-minikube            1/1     Running   0          49s
```
2) Далее нам необходимо проверить участие `Replica Set` и `Daemon Set` в поднятии подов. Для этого выполним следующие команды и посмотрим на результат:
    ```shell
    ➜  ~ kubectl get ds -n kube-system
    NAME         DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR            AGE
    kube-proxy   1         1         1       1            1           kubernetes.io/os=linux   18m
    ➜  ~ kubectl get rs -n kube-system
    NAME                DESIRED   CURRENT   READY   AGE
    coredns-f9fd979d6   1         1         1       18m
    ```
3) По результату выше можно сделать вывод о том, что `kube-proxy` работает благодаря записи о нем в `Daemon Set`, а `coredns` с помощью `Replica Set`.
4) Остальные поды выглядят странно: у них нет динамического идентификатора, а значит принцип их работы отличается.
    После небольшого поиска в интернете, понял, что бывают динамические и статические поды. 
    Динамические поды поднимаются с помощью записи о них в `Replica Set` и `Daemon Set`.
    Статические поднимаются благодаря `kubelet` демону, который фиксирует статические поды по манифестам в директории `/etc/kubelet.d/` (по умолчанию) и "следит" за жизнью работающих статических подов.
    Сам `kubelet` востанавливает свою работу благодаря `linux` инструменту демонизации процессов `systemd`.
