### PR TITLE
adding user in Dockerfile

### DIFF
--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -7,7 +7,7 @@ metadata:
 spec: # Описание Pod
   containers: # Описание контейнеров внутри Pod
   - name: web # Название контейнера
-    image: registry.hub.docker.com/faoxis/otus-nginx:0.0.1 # Образ из которого создается контейнер
+    image: registry.hub.docker.com/faoxis/otus-nginx:0.0.4 # Образ из которого создается контейнер
     volumeMounts:
       - name: app
         mountPath: /app

--- a/kubernetes-intro/web/Dockerfile
+++ b/kubernetes-intro/web/Dockerfile
@@ -1,7 +1,15 @@
-from nginx:latest
+FROM nginx:latest
 
-RUN mkdir /app
 COPY web.conf /etc/nginx/conf.d/web.conf
 
+RUN mkdir /app \
+    && usermod -u 1001 nginx \
+    && groupmod -g 1001 nginx \
+    && chown -R nginx: /var/cache/nginx \
+    && touch /var/run/nginx.pid \
+    && chown nginx: /var/run/nginx.pid \
+    && chown -R nginx: /etc/nginx \
+    && rm /etc/nginx/conf.d/default.conf
 
 EXPOSE 8000
+USER 1001

--- a/kubernetes-intro/web/build-and-push.sh
+++ b/kubernetes-intro/web/build-and-push.sh
@@ -1,3 +1,3 @@
 docker login registry.hub.docker.com -u faoxis
-docker build . -t registry.hub.docker.com/faoxis/otus-nginx:0.0.1
-docker push registry.hub.docker.com/faoxis/otus-nginx:0.0.1
+docker build . -t registry.hub.docker.com/faoxis/otus-nginx:0.0.4
+docker push registry.hub.docker.com/faoxis/otus-nginx:0.0.4


### PR DESCRIPTION
## Домашняя работа 1. Введение в Kubernetes
### Порядок выполнения:
1) Установил `minikube`
2) Запусти `kubernetes` кластер командой `minikube start`
3) Создал [`Dockerfile`](kubernetes-intro/web/Dockerfile) с открытым портом `8000` и возможностью подгружать ресурсы из `/app/`.
4) Создал [манифест](kubernetes-intro/web-pod.yaml) с поднятием моего образа в `kubernetes` с `init` контейнером, который подкладывает файл `index.html` в папку с ресурсами.
5) Запустил под командой `kubectl apply -f web-pod.yaml`.
6) Убедился в работоспособности пода командой `kubectl describe pod web`.
7) Проверил, что скаченная страница подгружается командой `kubectl port-forward --address 0.0.0.0 pod/web 8000:8000`.
8) Получил файл с описанием нового сервис `frontend` командой `kubectl run frontend --image avtandilko/hipster-frontend:v0.0.1 --restart=Never --dry-run=client -o yaml > frontend-pod.yaml`.
9) Через команду `docker logs frontend` понял каких переменных окружения не хватает и добавил их в файле [`frontend-pod-health.yaml`](kubernetes-intro/frontend-pod-healthy.yaml).
### Ответы на вопросы:
#### Разберитесь почему все pod в namespace kube-system восстановились после удаления. Для ответа на вопрос попробуем проделать следующий действия:
1) Выполним команду `kubectl delete pod --all -n kube-system`, а затем `kubectl get pods -n kube-system`, чтобы убедиться, что поды на месте:
    ```shell
    NAME                               READY   STATUS    RESTARTS   AGE
    coredns-f9fd979d6-5d25r            1/1     Running   0          50s
    etcd-minikube                      1/1     Running   0          50s
    kube-apiserver-minikube            1/1     Running   0          50s
    kube-controller-manager-minikube   1/1     Running   0          50s
    kuяbe-proxy-nlw69                   1/1     Running   0          43s
    kube-scheduler-minikube            1/1     Running   0          49s
    ```
2) Далее нам необходимо проверить участие `Replica Set` и `Daemon Set` в поднятии подов. Для этого выполним следующие команды и посмотрим на результат:
    ```shell
    ➜  ~ kubectl get ds -n kube-system
    NAME         DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR            AGE
    kube-proxy   1         1         1       1            1           kubernetes.io/os=linux   18m
    ➜  ~ kubectl get rs -n kube-system
    NAME                DESIRED   CURRENT   READY   AGE
    coredns-f9fd979d6   1         1         1       18m
    ```
3) По результату выше можно сделать вывод о том, что `kube-proxy` работает благодаря записи о нем в `Daemon Set`, а `coredns` с помощью `Replica Set`.
4) Остальные поды выглядят странно: у них нет динамического идентификатора, а значит принцип их работы отличается.
    После небольшого поиска в интернете, понял, что бывают динамические и статические поды. 
    Динамические поды поднимаются с помощью записи о них в `Replica Set` и `Daemon Set`.
    Статические поднимаются благодаря `kubelet` демону, который фиксирует статические поды по манифестам в директории `/etc/kubelet.d/` (по умолчанию) и "следит" за жизнью работающих статических подов.
    Сам `kubelet` востанавливает свою работу благодаря `linux` инструменту демонизации процессов `systemd`.
