### PR TITLE
adding kubernetes controllers lesson

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,19 @@ Faoxis Platform repository
     Динамические поды поднимаются с помощью записи о них в `Replica Set` и `Daemon Set`.
     Статические поднимаются благодаря `kubelet` демону, который фиксирует статические поды по манифестам в директории `/etc/kubelet.d/` (по умолчанию) и "следит" за жизнью работающих статических подов.
     Сам `kubelet` востанавливает свою работу благодаря `linux` инструменту демонизации процессов `systemd`.
+
+
+
+## Домашняя работа 2. Введение в контроллеры
+### Порядок выполнения:
+1) Создал кластер kind с [3 мастер нодами и 3-мя воркерами](kubernetes-controllers/kind-config.yaml)
+2) Создал [frontend replicaset](kubernetes-controllers/frontend-replicaset.yaml) и задеблоил в `kind`
+3) Попробовал обновить replicaset с новой версией и убедился, что не получилось с помощью команд 
+   `kubectl get replicaset frontend -o=jsonpath='{.spec.template.spec.containers[0].image}'` (убедился, что реплика сет обновился) 
+   и `kubectl get pods -l app=frontend -o=jsonpath='{.items[0:3].spec.containers[0].image}'` (убедился, что версия подов не изменилась)
+4) Обновление подов не происходит по той причине, что обновление образа в `replica set` не несет за собой 
+5) На примере [paymentservice-deployment.yaml](kubernetes-controllers/paymentservice-deployment.yaml) удалось убедиться,
+    что сущность `Deployment` решает проблему.
+6) Кроме того, на примере образа `node-exporter` понял как работает [`DaemonSet`](kubernetes-controllers/node-exporter-daemonset.yaml),
+    что позволяет очень просто настроить мониторинг всех нод, включая `master` ноды.
+7) В процессе выполнения были сделаны все дополнительные задания. Было очень интересно.

--- a/kubernetes-controllers/frontend-deployment.yaml
+++ b/kubernetes-controllers/frontend-deployment.yaml
@@ -20,7 +20,7 @@ spec:
           readinessProbe:
             initialDelaySeconds: 10
             httpGet:
-              path: "/_health"
+              path: "/_healthz"
               port: 8080
               httpHeaders:
                 - name: "Cookie"

--- a/kubernetes-controllers/frontend-deployment.yaml
+++ b/kubernetes-controllers/frontend-deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+        - name: server
+          image: faoxis/hipster-frontend:0.0.2
+          readinessProbe:
+            initialDelaySeconds: 10
+            httpGet:
+              path: "/_health"
+              port: 8080
+              httpHeaders:
+                - name: "Cookie"
+                  value: "shop_session-id=x-readiness-probe"
+          env:
+            - name: PRODUCT_CATALOG_SERVICE_ADDR
+              value: "productcatalogservice:3550"
+            - name: CURRENCY_SERVICE_ADDR
+              value: "currencyservice:7000"
+            - name: CART_SERVICE_ADDR
+              value: "cartservice:7070"
+            - name: RECOMMENDATION_SERVICE_ADDR
+              value: "recommendationservice:8080"
+            - name: SHIPPING_SERVICE_ADDR
+              value: "shippingservice:50051"
+            - name: CHECKOUT_SERVICE_ADDR
+              value: "checkoutservice:5050"
+            - name: AD_SERVICE_ADDR
+              value: "adservice:9555"
+            - name: ENV_PLATFORM
+              value: "gcp"

--- a/kubernetes-controllers/frontend-replicaset.yaml
+++ b/kubernetes-controllers/frontend-replicaset.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+      - name: server
+        image: faoxis/hipster-frontend:0.0.2
+        env:
+          - name: PRODUCT_CATALOG_SERVICE_ADDR
+            value: "productcatalogservice:3550"
+          - name: CURRENCY_SERVICE_ADDR
+            value: "currencyservice:7000"
+          - name: CART_SERVICE_ADDR
+            value: "cartservice:7070"
+          - name: RECOMMENDATION_SERVICE_ADDR
+            value: "recommendationservice:8080"
+          - name: SHIPPING_SERVICE_ADDR
+            value: "shippingservice:50051"
+          - name: CHECKOUT_SERVICE_ADDR
+            value: "checkoutservice:5050"
+          - name: AD_SERVICE_ADDR
+            value: "adservice:9555"
+          - name: ENV_PLATFORM
+            value: "gcp"

--- a/kubernetes-controllers/kind-config.yaml
+++ b/kubernetes-controllers/kind-config.yaml
@@ -1,0 +1,9 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+  - role: control-plane
+  - role: control-plane
+  - role: worker
+  - role: worker
+  - role: worker

--- a/kubernetes-controllers/node-exporter-daemonset.yaml
+++ b/kubernetes-controllers/node-exporter-daemonset.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app.kubernetes.io/name: node-exporter
+    app.kubernetes.io/version: v1.0.1
+  name: node-exporter
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: node-exporter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: node-exporter
+        app.kubernetes.io/version: v1.0.1
+    spec:
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+      containers:
+        - args:
+            - --web.listen-address=127.0.0.1:9100
+            - --path.procfs=/host/proc
+            - --path.sysfs=/host/sys
+            - --path.rootfs=/host/root
+            - --no-collector.wifi
+            - --no-collector.hwmon
+            - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)
+          image: quay.io/prometheus/node-exporter:v1.0.1
+          name: node-exporter
+          resources:
+            limits:
+              cpu: 250m
+              memory: 180Mi
+            requests:
+              cpu: 102m
+              memory: 180Mi
+          volumeMounts:
+            - mountPath: /host/proc
+              mountPropagation: HostToContainer
+              name: proc
+              readOnly: true
+            - mountPath: /host/sys
+              mountPropagation: HostToContainer
+              name: sys
+              readOnly: true
+            - mountPath: /host/root
+              mountPropagation: HostToContainer
+              name: root
+              readOnly: true
+      hostNetwork: true
+      hostPID: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      volumes:
+        - hostPath:
+            path: /proc
+          name: proc
+        - hostPath:
+            path: /sys
+          name: sys
+        - hostPath:
+            path: /
+          name: root
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%
+    type: RollingUpdate

--- a/kubernetes-controllers/paymentservice-deployment-bg.yaml
+++ b/kubernetes-controllers/paymentservice-deployment-bg.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: paymentservice
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 3
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+        - name: server
+          image: faoxis/paymentservice:0.0.2

--- a/kubernetes-controllers/paymentservice-deployment-reverse.yaml
+++ b/kubernetes-controllers/paymentservice-deployment-reverse.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: paymentservice
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+        - name: server
+          image: faoxis/paymentservice:0.0.2

--- a/kubernetes-controllers/paymentservice-deployment.yaml
+++ b/kubernetes-controllers/paymentservice-deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+        - name: server
+          image: faoxis/paymentservice:0.0.1

--- a/kubernetes-controllers/paymentservice-replicaset.yaml
+++ b/kubernetes-controllers/paymentservice-replicaset.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+        - name: server
+          image: faoxis/paymentservice:0.0.1


### PR DESCRIPTION
## Домашняя работа 2. Введение в контроллеры
### Порядок выполнения:
1) Создал кластер kind с [3 мастер нодами и 3-мя воркерами](kubernetes-controllers/kind-config.yaml)
2) Создал [frontend replicaset](kubernetes-controllers/frontend-replicaset.yaml) и задеблоил в `kind`
3) Попробовал обновить replicaset с новой версией и убедился, что не получилось с помощью команд 
   `kubectl get replicaset frontend -o=jsonpath='{.spec.template.spec.containers[0].image}'` (убедился, что реплика сет обновился) 
   и `kubectl get pods -l app=frontend -o=jsonpath='{.items[0:3].spec.containers[0].image}'` (убедился, что версия подов не изменилась)
4) Обновление подов не происходит по той причине, что обновление образа в `replica set` не несет за собой 
5) На примере [paymentservice-deployment.yaml](kubernetes-controllers/paymentservice-deployment.yaml) удалось убедиться,
    что сущность `Deployment` решает проблему.
6) Кроме того, на примере образа `node-exporter` понял как работает [`DaemonSet`](kubernetes-controllers/node-exporter-daemonset.yaml),
    что позволяет очень просто настроить мониторинг всех нод, включая `master` ноды.
7) В процессе выполнения были сделаны все дополнительные задания. Было очень интересно.
